### PR TITLE
Parse HTTP message body

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -116,6 +116,9 @@ class Socket {
   func read(bytes: Int) throws -> [CChar] {
     let data = Data(capacity: bytes)
     let bytes = system_read(descriptor, data.bytes, data.capacity)
+    guard bytes != -1 else {
+        throw SocketError()
+    }
     return Array(data.characters[0..<bytes])
   }
 

--- a/Tests/HTTPParserSpec.swift
+++ b/Tests/HTTPParserSpec.swift
@@ -35,8 +35,6 @@ describe("HTTPParser") {
 
   $0.it("can parse a HTTP request body") {
     outSocket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
-    outSocket.write("some_body_data")
-    outSocket.close()
 
     let request = try parser.parse()
     try expect(request.method) == "GET"
@@ -46,11 +44,9 @@ describe("HTTPParser") {
     let header = request.headers[0]
     try expect(header.0) == "Host"
     try expect(header.1) == "localhost"
-
-    try expect(request.body) == "some_body_data"
   }
 
-  $0.it("respects Content-Length when parsing an HTTP request body") {
+  $0.it("reads the message body when Content-Length is present") {
     outSocket.write("GET / HTTP/1.1\r\nContent-Length: 5\r\n\r\nabcdefgh")
 
     let request = try parser.parse()

--- a/Tests/HTTPParserSpec.swift
+++ b/Tests/HTTPParserSpec.swift
@@ -69,6 +69,14 @@ describe("HTTPParser") {
 
     try expect(try parser.parse()).toThrow()
   }
+
+  $0.it("throws an error when the client disconnects before sending the entire message body") {
+    outSocket.write("GET / HTTP/1.1\r\nContent-Length: 42\r\n\r\nabcdefgh")
+    outSocket.close()
+    outSocket = nil
+
+    try expect(try parser.parse()).toThrow()
+  }
 }
 
 }

--- a/Tests/HTTPParserSpec.swift
+++ b/Tests/HTTPParserSpec.swift
@@ -35,6 +35,8 @@ describe("HTTPParser") {
 
   $0.it("can parse a HTTP request body") {
     outSocket.write("GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    outSocket.write("some_body_data")
+    outSocket.close()
 
     let request = try parser.parse()
     try expect(request.method) == "GET"
@@ -44,6 +46,15 @@ describe("HTTPParser") {
     let header = request.headers[0]
     try expect(header.0) == "Host"
     try expect(header.1) == "localhost"
+
+    try expect(request.body) == "some_body_data"
+  }
+
+  $0.it("respects Content-Length when parsing an HTTP request body") {
+    outSocket.write("GET / HTTP/1.1\r\nContent-Length: 5\r\n\r\nabcdefgh")
+
+    let request = try parser.parse()
+    try expect(request.body) == "abcde"
   }
 
   $0.it("throws an error when the client uses bad HTTP syntax") {


### PR DESCRIPTION
I was trying to put together a slightly less trivial demo app and realized that there was no logic yet for reading in body data. This is a first pass at implementing that behavior. It only tries to read the body if the `Content-Length` header is present and doesn't try to deal with `Transfer-Encoding` at all, but this seems to be sufficient for the basic case that I'm looking for right now.