### PR TITLE
fix Socket.blocking implementation

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -150,7 +150,7 @@ class Socket {
   var blocking: Bool {
     get {
       let flags = fcntl(descriptor, F_GETFL, 0)
-      return flags & O_NONBLOCK == 1
+      return flags & O_NONBLOCK == 0
     }
 
     set {
@@ -158,7 +158,7 @@ class Socket {
       let newFlags: Int32
 
       if newValue {
-        newFlags = flags ^ O_NONBLOCK
+        newFlags = flags & ~O_NONBLOCK
       } else {
         newFlags = flags | O_NONBLOCK
       }


### PR DESCRIPTION
Setting `Socket.blocking` to false didn't correctly clear the bit in all cases.

If the flag was set before, it was cleared correctly. If the flag was not set, however, `0 ^ 1` would result in the bit being set accidentally.

This fixes kylef/Curassow-example-helloworld#3.