### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import PackageDescription
 let package = Package(
   name: "HelloWorld",
   dependencies: [
-    .Package(url: "https://github.com/kylef/Curassow.git", majorVersion: 0, minor: 1),
+    .Package(url: "https://github.com/kylef/Curassow.git", majorVersion: 0, minor: 2),
   ]
 )
 ```


### PR DESCRIPTION
Not 100% sure how the Swift PM works just yet, but if you specify `minor: 1`, it won't download the latest release (e.g., 0.2.3). I'm assuming `minor: 1` limits us to just `0.1.x`.

Came across this issue while trying to install Currasow for the first time via the Swift PM. Everything linked properly when I changed the minor version to 2.