### PR TITLE
exposing port specifier locally in serve api

### DIFF
--- a/Sources/Curassow.swift
+++ b/Sources/Curassow.swift
@@ -34,10 +34,10 @@ extension Address : ArgumentConvertible {
 }
 
 
-@noreturn public func serve(closure: RequestType -> ResponseType) {
+@noreturn public func serve(port: UInt16 = 8000, closure: RequestType -> ResponseType) {
   command(
     Option("workers", 1, description: "The number of processes for handling requests."),
-    Option("bind", Address.IP(hostname: "0.0.0.0", port: 8000), description: "The address to bind sockets."),
+    Option("bind", Address.IP(hostname: "0.0.0.0", port: port), description: "The address to bind sockets."),
     Option("timeout", 30, description: "Amount of seconds to wait on a worker without activity before killing and restarting the worker.")
   ) { workers, address, timeout in
     let arbiter = Arbiter<SyncronousWorker>(application: closure, workers: workers, addresses: [address], timeout: timeout)


### PR DESCRIPTION
Small pull request exposing the port api locally if user wants to specify it.  I don't see a reason not to expose this, let me know if it's unwanted for some reason.  