### PR TITLE
Expose an API for building custom worker types

### DIFF
--- a/Sources/Arbiter.swift
+++ b/Sources/Arbiter.swift
@@ -9,7 +9,7 @@ import Darwin.C
 import Nest
 
 
-enum Address : CustomStringConvertible {
+public enum Address : CustomStringConvertible {
   case IP(hostname: String, port: UInt16)
   case UNIX(path: String)
 
@@ -33,7 +33,7 @@ enum Address : CustomStringConvertible {
     }
   }
 
-  var description: String {
+  public var description: String {
     switch self {
     case let IP(hostname, port):
       return "\(hostname):\(port)"
@@ -45,7 +45,7 @@ enum Address : CustomStringConvertible {
 
 
 /// Arbiter maintains the worker processes
-class Arbiter<Worker : WorkerType> {
+public final class Arbiter<Worker : WorkerType> {
   let configuration: Configuration
   let logger = Logger()
   var listeners: [Socket] = []
@@ -57,7 +57,7 @@ class Arbiter<Worker : WorkerType> {
 
   var signalHandler: SignalHandler!
 
-  init(configuration: Configuration, workers: Int, application: Application) {
+  public init(configuration: Configuration, workers: Int, application: Application) {
     self.configuration = configuration
     self.numberOfWorkers = workers
     self.application = application
@@ -85,7 +85,7 @@ class Arbiter<Worker : WorkerType> {
   var running = false
 
   // Main run loop for the master process
-  func run() throws {
+  public func run() throws {
     running = true
 
     try registerSignals()

--- a/Sources/Configuration.swift
+++ b/Sources/Configuration.swift
@@ -1,0 +1,14 @@
+final class Configuration {
+  let addresses: [Address]
+
+  /// Workers silent for more than this many seconds are killed and restarted
+  let timeout: Int
+
+  let backlog: Int32
+
+  init(addresses: [Address] = [], timeout: Int = 30, backlog: Int32 = 2048) {
+    self.addresses = addresses
+    self.timeout = timeout
+    self.backlog = backlog
+  }
+}

--- a/Sources/Configuration.swift
+++ b/Sources/Configuration.swift
@@ -1,12 +1,12 @@
-final class Configuration {
+public final class Configuration {
   let addresses: [Address]
 
   /// Workers silent for more than this many seconds are killed and restarted
-  let timeout: Int
+  public let timeout: Int
 
   let backlog: Int32
 
-  init(addresses: [Address] = [], timeout: Int = 30, backlog: Int32 = 2048) {
+  public init(addresses: [Address] = [], timeout: Int = 30, backlog: Int32 = 2048) {
     self.addresses = addresses
     self.timeout = timeout
     self.backlog = backlog

--- a/Sources/Curassow.swift
+++ b/Sources/Curassow.swift
@@ -10,7 +10,7 @@ import Inquiline
 
 
 extension Address : ArgumentConvertible {
-  init(parser: ArgumentParser) throws {
+  public init(parser: ArgumentParser) throws {
     if let value = parser.shift() {
       if value.hasPrefix("unix:") {
         let prefixEnd = value.startIndex.advancedBy(5)

--- a/Sources/Curassow.swift
+++ b/Sources/Curassow.swift
@@ -40,7 +40,8 @@ extension Address : ArgumentConvertible {
     Option("bind", Address.IP(hostname: "0.0.0.0", port: 8000), description: "The address to bind sockets."),
     Option("timeout", 30, description: "Amount of seconds to wait on a worker without activity before killing and restarting the worker.")
   ) { workers, address, timeout in
-    let arbiter = Arbiter<SyncronousWorker>(application: closure, workers: workers, addresses: [address], timeout: timeout)
+    let configuration = Configuration(addresses: [address], timeout: timeout)
+    let arbiter = Arbiter<SyncronousWorker>(configuration: configuration, workers: workers, application: closure)
     try arbiter.run()
   }.run()
 }

--- a/Sources/Logger.swift
+++ b/Sources/Logger.swift
@@ -4,7 +4,8 @@ import Glibc
 import Darwin.C
 #endif
 
-class Logger {
+
+public final class Logger {
   func currentTime() -> String {
     var t = time(nil)
     let tm = localtime(&t)
@@ -13,11 +14,11 @@ class Logger {
     return date.string ?? "unknown"
   }
 
-  func info(message: String) {
+  public func info(message: String) {
     print("[\(currentTime())] [\(getpid())] [INFO] \(message)")
   }
 
-  func critical(message: String) {
+  public func critical(message: String) {
     print("[\(currentTime())] [\(getpid())] [CRITICAL] \(message)")
   }
 }

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -47,7 +47,7 @@ struct SocketError : ErrorType, CustomStringConvertible {
 
 
 /// Represents a TCP AF_INET/AF_UNIX socket
-class Socket {
+public final class Socket {
   typealias Descriptor = Int32
   typealias Port = UInt16
 

--- a/Sources/SyncronousWorker.swift
+++ b/Sources/SyncronousWorker.swift
@@ -9,21 +9,25 @@ import Inquiline
 
 
 final class SyncronousWorker : WorkerType {
+  let configuration: Configuration
   let logger: Logger
   let listeners: [Socket]
-  let timeout: Int
+
+  var timeout: Int {
+    return configuration.timeout / 2
+  }
+
+  let notify: Void -> Void
+
   let application: RequestType -> ResponseType
   var isAlive: Bool = false
-  let temp: WorkerTemp
-  var aborted: Bool = false
 
-  init(logger: Logger, listeners: [Socket], timeout: Int, application: RequestType -> ResponseType) {
+  init(configuration: Configuration, logger: Logger, listeners: [Socket], notify: Void -> Void, application: Application) {
     self.logger = logger
     self.listeners = listeners
-    self.timeout = timeout
+    self.configuration = configuration
+    self.notify = notify
     self.application = application
-
-    temp = WorkerTemp()
   }
 
   func registerSignals() throws {
@@ -77,10 +81,6 @@ final class SyncronousWorker : WorkerType {
 
   func handleTerminate() {
     isAlive = false
-  }
-
-  func notify() {
-    temp.notify()
   }
 
   func wait() -> [Socket] {

--- a/Sources/SyncronousWorker.swift
+++ b/Sources/SyncronousWorker.swift
@@ -8,7 +8,7 @@ import Nest
 import Inquiline
 
 
-final class SyncronousWorker : WorkerType {
+public final class SyncronousWorker : WorkerType {
   let configuration: Configuration
   let logger: Logger
   let listeners: [Socket]
@@ -22,7 +22,7 @@ final class SyncronousWorker : WorkerType {
   let application: RequestType -> ResponseType
   var isAlive: Bool = false
 
-  init(configuration: Configuration, logger: Logger, listeners: [Socket], notify: Void -> Void, application: Application) {
+  public init(configuration: Configuration, logger: Logger, listeners: [Socket], notify: Void -> Void, application: Application) {
     self.logger = logger
     self.listeners = listeners
     self.configuration = configuration
@@ -39,7 +39,7 @@ final class SyncronousWorker : WorkerType {
     SignalHandler.registerSignals()
   }
 
-  func run() {
+  public func run() {
     logger.info("Booting worker process with pid: \(getpid())")
 
     do {

--- a/Sources/Worker.swift
+++ b/Sources/Worker.swift
@@ -8,10 +8,10 @@ import Nest
 import Inquiline
 
 
-typealias Application = RequestType -> ResponseType
+public typealias Application = RequestType -> ResponseType
 
 
-protocol WorkerType {
+public protocol WorkerType {
   /*** Initialises the worker
   - Parameters:
       - configuration

--- a/Sources/Worker.swift
+++ b/Sources/Worker.swift
@@ -8,17 +8,41 @@ import Nest
 import Inquiline
 
 
+typealias Application = RequestType -> ResponseType
+
+
 protocol WorkerType {
-  /// Initialises the worker
-  init(logger: Logger, listeners: [Socket], timeout: Int, application: RequestType -> ResponseType)
+  /*** Initialises the worker
+  - Parameters:
+      - configuration
+      - logger
+      - listeners
+      - notify: A notify callback, this should be retained and invoked to notify the arbiter of your existance to prevent timeouts
+      - application: The users Nest application
 
-  var temp: WorkerTemp { get }
+  NOTE: This is invoked from the master process
+  */
+  init(configuration: Configuration, logger: Logger, listeners: [Socket], notify: Void -> Void, application: Application)
 
-  /// Indicates when the worker has been aborted, mostly used by the arbiter
-  var aborted: Bool { get set }
+  /*** Runs the worker
+  The implementation should start listening for requests on the listeners,
+  and invoke the notify callback before `configuration.timeout` happens.
 
-  /// Runs the worker
+  NOTE: This is invoked from the workers fork
+  **/
   func run()
+}
+
+
+// Represents a worker
+final class WorkerProcess {
+  /// Indicates when the worker has been aborted, used by the arbiter
+  var aborted: Bool = false
+  let temp = WorkerTemp()
+
+  func notify() {
+    temp.notify()
+  }
 }
 
 


### PR DESCRIPTION
Using Arbiter with existing, or custom worker types:

```swift
let configuration = Configuration(addresses: [.IP(hostname: "0.0.0.0", port: 8080)])
let arbiter = Arbiter<SyncronousWorker>(configuration: configuration, workers: 3, application: nestApplication)
try arbiter.run()
```

Building a custom worker type:

```swift
class CustomWorker: WorkerType {
  let configuration: Configuration
  let logger: Logger
  let notify: Void -> Void
  let application: Application

  init(configuration: Configuration, logger: Logger, listeners: [Socket], notify: Void -> Void, application: Application) {
    self.configuration = configuration
    self.logger = logger
    self.notify = notify
    self.application = application
  }

  func run() {
    // Listen for connections on the provided listeners
    // Construct a request and pass it to the application to get a response
    // Call `notify` before `configuration.timeout` to prevent timing out and getting killed
  }
}
```