### PR TITLE
Prepare for Swift 3

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -34,8 +34,8 @@ private let system_pipe = Darwin.pipe
 struct SocketError : ErrorType, CustomStringConvertible {
   let function: String
   let number: Int32
-
-  init(function: String = __FUNCTION__) {
+  
+  init(function: String = #function ) {
     self.function = function
     self.number = errno
   }


### PR DESCRIPTION
This rename the only instance of `__FUNCTION__` to `#function` which is now obsolete according to the compiler and this proposal: https://github.com/apple/swift-evolution/blob/master/proposals/0028-modernizing-debug-identifiers.md

EDIT: I thought this would be backward compatible to 2.2 while it is not.