### PR TITLE
Increased visibility of Arbiter.stop()

### DIFF
--- a/Sources/Arbiter.swift
+++ b/Sources/Arbiter.swift
@@ -86,7 +86,7 @@ public final class Arbiter<Worker : WorkerType> {
     halt()
   }
 
-  func stop(graceful: Bool = true) {
+  public func stop(graceful: Bool = true) {
     listeners.forEach { $0.close() }
 
     if graceful {


### PR DESCRIPTION
We need public access to `Arbiter.stop()` in order to properly integrate as a server driver for Vapor as per https://github.com/qutheory/vapor-curassow-server/pull/1.