### PR TITLE
Fix infinite recursion

### DIFF
--- a/Sources/HTTPParser.swift
+++ b/Sources/HTTPParser.swift
@@ -240,7 +240,7 @@ class ReaderPayload : PayloadType, PayloadConvertible, GeneratorType {
       return buffer
     }
 
-    if let remainingSize = remainingSize where remainingSize < 0 {
+    if let remainingSize = remainingSize where remainingSize <= 0 {
       return nil
     }
 


### PR DESCRIPTION
Previously, remainingSize when == 0 would cause a 0 read (successful) and would forever return `[]`
