### PR TITLE
Remove `result of call is unused` warnings

### DIFF
--- a/Sources/Curassow/SynchronousWorker.swift
+++ b/Sources/Curassow/SynchronousWorker.swift
@@ -73,7 +73,7 @@ public final class SynchronousWorker : WorkerType {
 
   func runOne(_ listener: Socket) {
     while isAlive {
-      sharedHandler?.process()
+      _ = sharedHandler?.process()
       notify()
       accept(listener)
 
@@ -81,13 +81,13 @@ public final class SynchronousWorker : WorkerType {
         return
       }
 
-      wait()
+      _ = wait()
     }
   }
 
   func runMultiple(_ listeners: [Socket]) {
     while isAlive {
-      sharedHandler?.process()
+      _ = sharedHandler?.process()
       notify()
 
       let sockets = wait().filter {


### PR DESCRIPTION
Hey! After running the Hello World project and in the Travis build I noticed the presence of three warnings during the build. Not sure if you like this style, so feel free to close this PR if it doesn't suit your style.
