### PR TITLE
Fix argument name in Quick Start example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ run your web application:
 
 
     serve { request in
-      return Response(.ok, contentType: "text/plain", body: "Hello World")
+      return Response(.ok, contentType: "text/plain", content: "Hello World")
     }
 
 Then build and run your application:


### PR DESCRIPTION
```
Sources/main.swift:6:51: error: argument 'body' must precede argument 'contentType'
  return Response(.ok, contentType: "text/plain", body: "Hello World")
                       ~~~~~~~~~~~~~~~~~~~~~~~~~  ^~~~~~~~~~~~~~~~~~~
                       body: "Hello World"        contentType: "text/plain"
<unknown>:0: error: build had 1 command failures
```